### PR TITLE
Add Hasura production deployment

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,16 @@
+## Useful commands
+
+Reset database
+
+```bash
+# Need to temporarily shutdown hasura we can't have users accessing the db while resetting
+kubectl scale --replicas=0 deployment/papergraph-hasura 
+argo submit --watch deploy/k8s/workflows/run.yaml -p cmd="diesel database reset"
+kubectl scale --replicas=1 deployment/papergraph-hasura 
+```
+
+Seed database
+
+```bash
+argo submit --watch deploy/k8s/workflows/seed.yaml 
+```

--- a/deploy/k8s/hasura-dev.yaml
+++ b/deploy/k8s/hasura-dev.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: papergraph-hasura-dev
+  labels:
+    app: papergraph
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: papergraph
+      tier: hasura-dev
+  template:
+    metadata:
+      labels:
+        app: papergraph
+        tier: hasura-dev
+    spec:
+      containers:
+        - name: hasura
+          image: hasura/graphql-engine:v1.2.0.cli-migrations-v2
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: papergraph-cloudsql
+                  key: password
+            - name: HASURA_GRAPHQL_DATABASE_URL
+              value: postgres://postgres:$(PGPASSWORD)@papergraph-cloudsql:5432/papergraph
+            - name: HASURA_GRAPHQL_ENABLED_LOG_TYPES
+              value: "startup, http-log, webhook-log, websocket-log, query-log"
+            - name: HASURA_GRAPHQL_ENABLE_CONSOLE
+              value: "true"

--- a/deploy/k8s/hasura.yaml
+++ b/deploy/k8s/hasura.yaml
@@ -1,4 +1,21 @@
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: papergraph-hasura
+  # annotations:
+  #   cloud.google.com/neg: '{"ingress": true}' # Creates a NEG after an Ingress is created
+  labels:
+    app: papergraph
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: papergraph
+    tier: hasura
+  type: NodePort
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,6 +40,18 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 1
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5        
           env:
             - name: PGPASSWORD
               valueFrom:
@@ -31,7 +60,11 @@ spec:
                   key: password
             - name: HASURA_GRAPHQL_DATABASE_URL
               value: postgres://postgres:$(PGPASSWORD)@papergraph-cloudsql:5432/papergraph
-            - name: HASURA_GRAPHQL_ENABLE_CONSOLE
-              value: "true"
             - name: HASURA_GRAPHQL_ENABLED_LOG_TYPES
               value: "startup, http-log, webhook-log, websocket-log, query-log"
+            # Disable console in production
+            - name: HASURA_GRAPHQL_ENABLE_CONSOLE
+              value: "false"
+            # Disable metadata and other APIs in production
+            - name: HASURA_GRAPHQL_ENABLED_APIS
+              value: graphql

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: papergraph-ingress
+spec:
+  # backend:
+  #   serviceName: papergraph-hasura
+  #   servicePort: 8080
+  rules:
+  - http:
+      paths:
+      - path: /v1/graphql
+        backend:
+          serviceName: papergraph-hasura
+          servicePort: 8080


### PR DESCRIPTION
Fixes #19

- Production hasura only exposes graphql endpoint, no metadata or console
- Production hasura is accessed via ingress controller
- Development hasura exposes console but is not exposed to public